### PR TITLE
Added parameters_aws for use with files already formatted in the AWS Cloudformation format

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Create, update, or delete the stack. The `parameters` and `tags` data should by 
 
  * **`template`** - path to a CloudFormation template (do not configure when enabling `delete`)
  * `parameters` - path to a JSON file
+ * `parameters_aws` - path to a aws cloudformation formatted JSON file
  * `tags` - path to a JSON file
  * `capabilities` - array of additional [capabilities](http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html) (e.g. `CAPABILITY_IAM`)
  * `delete` - set to `true` to delete the stack (default `false`)

--- a/bin/out
+++ b/bin/out
@@ -77,6 +77,7 @@ fi
 #
 
 PARAMETERS=$( jq -r '.params.parameters // ""' < /tmp/stdin )
+PARAMETERS_AWS=$( jq -r '.params.parameters_aws // ""' < /tmp/stdin )
 PARAMETERS_ARG=''
 
 if [ -n "$PARAMETERS" ] ; then
@@ -84,6 +85,9 @@ if [ -n "$PARAMETERS" ] ; then
     < "$PARAMETERS" \
     > /tmp/stack-parameters-new
   
+  PARAMETERS_ARG='--parameters=file:///tmp/stack-parameters-new'
+elif [ -n "$PARAMETERS_AWS" ] ; then
+  cp "$PARAMETERS_AWS" /tmp/stack-parameters-new
   PARAMETERS_ARG='--parameters=file:///tmp/stack-parameters-new'
 else
   echo '[]' > /tmp/stack-parameters-new


### PR DESCRIPTION
So we happen to have our parameter files stored in the AWS format, I would like to add an option for that.

I know this isn't the 'upstream' project but you have had a pull request open on that project since March, and I don't see them merging it anytime soon.
